### PR TITLE
Changes for HockeyApp 1.9

### DIFF
--- a/lib/hockeyapp/config.rb
+++ b/lib/hockeyapp/config.rb
@@ -2,7 +2,7 @@ module HockeyApp
   module Config
     extend self
 
-    ATTRIBUTES = [:token]
+    ATTRIBUTES = [:token, :base_uri]
 
     attr_accessor *ATTRIBUTES
 

--- a/lib/hockeyapp/models/version.rb
+++ b/lib/hockeyapp/models/version.rb
@@ -5,7 +5,7 @@ module HockeyApp
     include ActiveModel::Validations
     include ActiveModelCompliance
 
-    ATTRIBUTES = [:notes, :shortversion, :version, :mandatory, :timestamp, :appsize,  :title]
+    ATTRIBUTES = [:id, :notes, :shortversion, :version, :mandatory, :timestamp, :appsize,  :title, :download_url]
 
     POST_PAYLOAD = [:status, :ipa, :dsym, :notes_type, :notify, :tags]
 
@@ -50,21 +50,20 @@ module HockeyApp
 
 
     def to_key
-      [version] if persisted?
+      [@id] if persisted?
     end
 
     def crashes
-      @crashes ||= @app.crashes.select{|crash| "#{crash.app_version_id}" == version}
+      @crashes ||= @app.crashes.select{|crash| "#{crash.app_version_id}" == @id.to_s}
     end
 
     def crash_reasons
-      @crash_groups ||= @app.crash_reasons.select{|crash_reason| "#{crash_reason.app_version_id}" == version}
+      @crash_groups ||= @app.crash_reasons.select{|crash_reason| "#{crash_reason.app_version_id}" == @id.to_s}
     end
 
     def download_url
-      "#"
+      @download_url
     end
-
 
     private
 

--- a/lib/hockeyapp/ws/client.rb
+++ b/lib/hockeyapp/ws/client.rb
@@ -32,8 +32,8 @@ module HockeyApp
     end
 
     def get_versions app
-      versions = ws.get_versions app.public_identifier
-      versions.map{|version_hash|Version.from_hash(version_hash, app, self)}
+      versions_hash = ws.get_versions app.public_identifier
+      versions_hash["app_versions"].map{|version_hash|Version.from_hash(version_hash, app, self)}
     end
 
     def post_new_version version

--- a/lib/hockeyapp/ws/ws.rb
+++ b/lib/hockeyapp/ws/ws.rb
@@ -12,6 +12,7 @@ module HockeyApp
       @options = Config.to_h.merge(options)
       raise "No API Token Given" if (@options[:token].nil?)
       self.class.headers 'X-HockeyAppToken' => @options[:token]
+      self.class.base_uri @options[:base_uri] if @options[:base_uri].present?
     end
     
     
@@ -45,7 +46,7 @@ module HockeyApp
     end
 
     def get_versions app_id, options = {}
-      self.class.get "/apps/#{app_id}", options
+      self.class.get "/apps/#{app_id}/app_versions", options
     end
 
     def post_new_version(


### PR DESCRIPTION
HockeyApp 1.9 now includes the version ID in response to versions#index. In addition, this action can be called with a read-only token as well, then the JSON only includes downloadable versions.
