### PR TITLE
Add support for tags and upated 'notify' option statuses

### DIFF
--- a/lib/hockeyapp/models/app.rb
+++ b/lib/hockeyapp/models/app.rb
@@ -91,11 +91,12 @@ module HockeyApp
       url_strategy.install_url
     end
 
-    def create_version file, release_notes = "", notify = :none, tags = ""
+    def create_version file, release_notes = "", notify = :none, status = :allow , tags = ""
       version = Version.new(self, @client)
       version.ipa = file
       version.notes = release_notes
       version.notify = notify
+      version.status = status
       version.tags = tags
       client.post_new_version version
       @versions = nil

--- a/lib/hockeyapp/models/app.rb
+++ b/lib/hockeyapp/models/app.rb
@@ -91,10 +91,12 @@ module HockeyApp
       url_strategy.install_url
     end
 
-    def create_version file, release_notes = ""
+    def create_version file, release_notes = "", notify = :none, tags = ""
       version = Version.new(self, @client)
       version.ipa = file
       version.notes = release_notes
+      version.notify = notify
+      version.tags = tags
       client.post_new_version version
       @versions = nil
     end

--- a/lib/hockeyapp/models/version.rb
+++ b/lib/hockeyapp/models/version.rb
@@ -16,8 +16,9 @@ module HockeyApp
 
 
     NOTIFY_TO_BOOL = {
-        0 => false,
-        1 => true
+        0 => :none,
+        1 => :all_allowed,
+	2 => :all
     }
 
     STATUS_TO_SYM = {
@@ -78,7 +79,7 @@ module HockeyApp
       @dsym=nil
       @notes="New version"
       @notes_type=Version::NOTES_TYPES_TO_SYM.invert[:textile]
-      @notify=Version::NOTIFY_TO_BOOL.invert[false]
+      @notify=Version::NOTIFY_TO_BOOL.invert[:none]
       @status=Version::STATUS_TO_SYM.invert[:allow]
     end
 

--- a/lib/hockeyapp/ws/client.rb
+++ b/lib/hockeyapp/ws/client.rb
@@ -40,7 +40,7 @@ module HockeyApp
       app_id = version.app.public_identifier
       ipa = version.ipa
       raise "There must be an executable file" if ipa.nil?
-      version_hash = ws.post_new_version(app_id, ipa, version.dsym, version.notes, version.notes_type, version.notify, version.status)
+      version_hash = ws.post_new_version(app_id, ipa, version.dsym, version.notes, version.notes_type, version.notify, version.status, version.tags)
       raise version_hash['errors'].map{|e|e.to_s}.join("\n") unless version_hash['errors'].nil?
       Version.from_hash(version_hash, version.app, self)
     end

--- a/lib/hockeyapp/ws/ws.rb
+++ b/lib/hockeyapp/ws/ws.rb
@@ -55,8 +55,9 @@ module HockeyApp
             dsym=nil,
             notes="New version",
             notes_type=Version::NOTES_TYPES_TO_SYM.invert[:textile],
-            notify=Version::NOTIFY_TO_BOOL.invert[false],
-            status=Version::STATUS_TO_SYM.invert[:allow]
+            notify=Version::NOTIFY_TO_BOOL.invert[:none],
+            status=Version::STATUS_TO_SYM.invert[:allow],
+            tags=''
     )
       params = {
           :ipa => ipa ,
@@ -64,7 +65,8 @@ module HockeyApp
           :notes => notes,
           :notes_type => notes_type,
           :notify => notify,
-          :status => status
+          :status => status,
+          :tags => tags
       }
       params.reject!{|_,v|v.nil?}
       self.class.post "/apps/#{app_id}/app_versions/upload", :body => params


### PR DESCRIPTION
Added support for tags.
Updated 'notify' statuses (see http://support.hockeyapp.net/kb/api/api-versions#upload-version)
Added option to pass "notify" and "tags" options when using App.create_version
