### PR TITLE
Added support for app_versions/ID/crash_reasons endpoint

### DIFF
--- a/hockeyapp.gemspec
+++ b/hockeyapp.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "hockeyapp"
-  s.version     = "0.0.15"
+  s.version     = "0.0.16"
   s.authors     = ["Philippe Van Eerdenbrugghe", "Paul Renson"]
   s.email       = ["philippe.vaneerdenbrugghe@tapptic.com", "paul.renson.ext@tapptic.com"]
   s.homepage    = ""

--- a/hockeyapp.gemspec
+++ b/hockeyapp.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "hockeyapp"
-  s.version     = "0.0.16"
+  s.version     = "0.0.17"
   s.authors     = ["Philippe Van Eerdenbrugghe", "Paul Renson"]
   s.email       = ["philippe.vaneerdenbrugghe@tapptic.com", "paul.renson.ext@tapptic.com"]
   s.homepage    = ""

--- a/lib/hockeyapp/models/crash_group.rb
+++ b/lib/hockeyapp/models/crash_group.rb
@@ -10,7 +10,7 @@ module HockeyApp
 
 
     attr_accessor *ATTRIBUTES
-    attr_reader :application
+    attr_reader :app
 
 
     def self.from_hash(h, app, client)
@@ -22,11 +22,14 @@ module HockeyApp
       res
     end
 
-    def initialize application, client
-      @application = application
+    def initialize app, client
+      @app = app
       @client = client
     end
 
+    def crashes options = {}
+      @crashes ||= client.get_crashes_for_crash_group(self, options)
+    end
 
     private
 

--- a/lib/hockeyapp/models/version.rb
+++ b/lib/hockeyapp/models/version.rb
@@ -57,8 +57,8 @@ module HockeyApp
       @crashes ||= @app.crashes.select{|crash| "#{crash.app_version_id}" == @id.to_s}
     end
 
-    def crash_reasons
-      @crash_groups ||= @app.crash_reasons.select{|crash_reason| "#{crash_reason.app_version_id}" == @id.to_s}
+    def crash_reasons options = {}
+      @crash_groups ||= client.get_crash_groups_for_version(self, options)
     end
 
 

--- a/lib/hockeyapp/ws/client.rb
+++ b/lib/hockeyapp/ws/client.rb
@@ -17,6 +17,12 @@ module HockeyApp
       crashes_hash["crashes"].map{|crash_hash|Crash.from_hash(crash_hash, app, self)}
     end
 
+    def get_crashes_for_crash_group group, options = {}
+      crashes_hash = ws.get_crashes_for_group group.app.public_identifier, group.id, {query:options}
+      assert_success crashes_hash
+      crashes_hash["crashes"].map{|crash_hash|Crash.from_hash(crash_hash, group.app, self)}
+    end
+
     def get_crash_groups app
       crash_groups_hash = ws.get_crash_groups app.public_identifier
       assert_success crash_groups_hash
@@ -26,7 +32,7 @@ module HockeyApp
     def get_crash_groups_for_version version, options = {}
       crash_groups_hash = ws.get_crash_groups_for_version version.app.public_identifier, version.id, {query:options}
       assert_success crash_groups_hash
-      crash_groups_hash["crash_reasons"].map{|reason_hash|CrashGroup.from_hash(reason_hash,version.app,self)}
+      crash_groups_hash["crash_reasons"].map{|reason_hash|CrashGroup.from_hash(reason_hash, version.app, self)}
     end
 
     def get_crash_log crash

--- a/lib/hockeyapp/ws/client.rb
+++ b/lib/hockeyapp/ws/client.rb
@@ -23,6 +23,12 @@ module HockeyApp
       crash_groups_hash["crash_reasons"].map{|reason_hash|CrashGroup.from_hash(reason_hash, app, self)}
     end
 
+    def get_crash_groups_for_version version, options = {}
+      crash_groups_hash = ws.get_crash_groups_for_version version.app.public_identifier, version.id, {query:options}
+      assert_success crash_groups_hash
+      crash_groups_hash["crash_reasons"].map{|reason_hash|CrashGroup.from_hash(reason_hash,version.app,self)}
+    end
+
     def get_crash_log crash
       ws.get_crash_log crash.app.public_identifier, crash.id
     end

--- a/lib/hockeyapp/ws/ws.rb
+++ b/lib/hockeyapp/ws/ws.rb
@@ -33,6 +33,10 @@ module HockeyApp
       self.class.get "/apps/#{app_id}/app_versions/#{version_id}/crash_reasons", options
     end
 
+    def get_crashes_for_group app_id, group_id, options = {}
+      self.class.get "/apps/#{app_id}/crash_reasons/#{group_id}", options
+    end
+
     # this is damn not thread safe !
     def get_crash_log app_id, crash_id, options = {}
       self.class.format :plain

--- a/lib/hockeyapp/ws/ws.rb
+++ b/lib/hockeyapp/ws/ws.rb
@@ -29,6 +29,10 @@ module HockeyApp
       self.class.get "/apps/#{app_id}/crash_reasons", options
     end
 
+    def get_crash_groups_for_version app_id, version_id, options = {}
+      self.class.get "/apps/#{app_id}/app_versions/#{version_id}/crash_reasons", options
+    end
+
     # this is damn not thread safe !
     def get_crash_log app_id, crash_id, options = {}
       self.class.format :plain

--- a/spec/models/crash_group_spec.rb
+++ b/spec/models/crash_group_spec.rb
@@ -25,6 +25,7 @@ describe HockeyApp::CrashGroup do
       @app = HockeyApp::App.from_hash( {"public_identifier" => "91423bc5519dd2462513abbb54598959"}, @client)
       @crash_group = HockeyApp::CrashGroup.from_hash h, @app, @client
       @model = @crash_group
+      @options = {}
     end
 
     it_behaves_like "ActiveModel"
@@ -47,7 +48,12 @@ describe HockeyApp::CrashGroup do
       @crash_group.app_id.should == 9999
     end
 
-
+    it "calls client once when asked for crashes" do
+      @client.should_receive(:get_crashes_for_crash_group).with(@crash_group, @options).and_return([])
+      @crash_group.crashes
+      @client.should_not_receive(:get_crashes_for_crash_group).with(@crash_group, @options)
+      @crash_group.crashes
+    end
 
 end
 

--- a/spec/models/version_spec.rb
+++ b/spec/models/version_spec.rb
@@ -20,6 +20,7 @@ describe HockeyApp::Version do
     @app = HockeyApp::App.from_hash( {"public_identifier" => "91423bc5519dd2462513abbb54598959"}, @client)
     @version = HockeyApp::Version.from_hash @h, @app, @client
     @model = @version
+    @options = {}
   end
 
   subject{@version}
@@ -46,9 +47,9 @@ describe HockeyApp::Version do
   end
 
   it "calls client once when asked for crash groups" do
-    @client.should_receive(:get_crash_groups_for_version).with(@version).and_return([])
+    @client.should_receive(:get_crash_groups_for_version).with(@version, @options).and_return([])
     @version.crash_reasons
-    @client.should_not_receive(:get_crash_groups_for_version).with(@version)
+    @client.should_not_receive(:get_crash_groups_for_version).with(@version, @options)
     @version.crash_reasons
   end
 

--- a/spec/models/version_spec.rb
+++ b/spec/models/version_spec.rb
@@ -41,14 +41,14 @@ describe HockeyApp::Version do
   it "calls client once  when asked for crashes" do
     @client.should_receive(:get_crashes).with(@app).and_return([])
     @version.crashes
-    @client.should_not_receive(:get_crashes).with(@app)
+    @client.should_not_receive(:get_crashes)
     @version.crashes
   end
 
   it "calls client once when asked for crash groups" do
-    @client.should_receive(:get_crash_groups).with(@app).and_return([])
+    @client.should_receive(:get_crash_groups_for_version).with(@version).and_return([])
     @version.crash_reasons
-    @client.should_not_receive(:get_crash_groups).with(@app)
+    @client.should_not_receive(:get_crash_groups_for_version).with(@version)
     @version.crash_reasons
   end
 

--- a/spec/support/rspec_helper.rb
+++ b/spec/support/rspec_helper.rb
@@ -9,6 +9,7 @@ end
 
 
 require 'hockeyapp'
+require 'minitest/autorun'
 require_relative 'fake_ws'
 require_relative 'active_model_lint'
 


### PR DESCRIPTION
A very basic implementation exposing this endpoint. See http://support.hockeyapp.net/kb/api/api-crashes#-u-get-api-2-apps-app_id-app_versions-id-crash_reasons-u-
